### PR TITLE
Disable warnings in development mode (port to 0.4)

### DIFF
--- a/src/Snap/Extension/Loader/Devel.hs
+++ b/src/Snap/Extension/Loader/Devel.hs
@@ -134,7 +134,11 @@ hintSnap opts modules srcPaths initialization handler =
 
         interpret action (as :: HintLoadable)
 
-    loadInterpreter = unsafeRunInterpreterWithArgs opts interpreter
+    -- We ignore all warnings with '-w', otherwise a warning would result in an
+    -- UnknownError and thus prevent reloading.
+    opts' = opts ++ ["-w"]
+
+    loadInterpreter = unsafeRunInterpreterWithArgs opts' interpreter
 
     formatOnError (Left err) = error $ format err
     formatOnError (Right a) = a


### PR DESCRIPTION
Currently reloading does not work if some module produces warnings (e. g. unused imports). This patch works for me. What do you think?
