### PR TITLE
update git source-repository url to github 

### DIFF
--- a/snap.cabal
+++ b/snap.cabal
@@ -120,4 +120,4 @@ Executable snap
 
 source-repository head
   type:     git
-  location: http://git.snapframework.com/snap.git
+  location: https://github.com/snapframework/snap.git


### PR DESCRIPTION
Similar change needed for snap-core, snap-server, etc.
