### PR TITLE
`time` version constraint harmonization

### DIFF
--- a/snap.cabal
+++ b/snap.cabal
@@ -71,7 +71,7 @@ Library
     snap-core                 >= 0.5.3 && <0.6,
     heist                     >= 0.5 && < 0.6,
     template-haskell          >= 2.3 && < 2.7,
-    time                      >= 1.0 && < 1.3
+    time
 
   if flag(hint)
     build-depends:


### PR DESCRIPTION
...otherwise this causes annoying conflicts since `time-1.3` has been released and gets picked up by `snap-core` and `snap-server` but not by `snap`
