### PR TITLE
Use existential types to run AuthManager handlers with the auth backend

### DIFF
--- a/src/Snap/Snaplet/Auth.hs
+++ b/src/Snap/Snaplet/Auth.hs
@@ -19,6 +19,7 @@ module Snap.Snaplet.Auth
 
   -- * Higher Level Handler Functions
     createUser
+  , usernameExists
   , saveUser
   , destroyUser
   , loginByUsername


### PR DESCRIPTION
Instead of pattern-matching against the AuthManager ctor, we can use a `withBackend :: (forall r. (IAuthBackend r) => r -> Handler b (AuthManager v) a) -> Handler b (AuthManager v) a`. The handlers in Snap.Snaplet.Auth.Handlers have been rewritten to use this.

This also adds a usernameExists function.
