### PR TITLE
Support roles in AuthUser

### DIFF
--- a/src/Snap/Snaplet/Auth/Types.hs
+++ b/src/Snap/Snaplet/Auth/Types.hs
@@ -250,7 +250,7 @@ instance FromJSON AuthUser where
     <*> v .: "last_ip"
     <*> v .: "created_at"
     <*> v .: "updated_at"
-    <*> v .: "roles"
+    <*> v .:? "roles" .!= []
     <*> v .: "meta"
   parseJSON _ = error "Unexpected JSON input"
 


### PR DESCRIPTION
Somewhy the existing implementation of Auth infrastructure doesn't
support user roles properly, not maintaining roles list in data store
at all. This simple patch fixes that. The patch is tested in a project
I'm working on.

Note that data stores created with previous versions of AuthManager
will cause the error:

```
Malformed JSON auth data store. Error: key "roles" not present
```
