### PR TITLE
Add RecordWildCards extension declaration to snap.cabal in order to make...

### DIFF
--- a/snap.cabal
+++ b/snap.cabal
@@ -177,6 +177,7 @@ Library
     OverloadedStrings,
     PackageImports,
     Rank2Types,
+    RecordWildCards,
     ScopedTypeVariables,
     TemplateHaskell,
     TypeFamilies,


### PR DESCRIPTION
... it to compile with ghc-7.4 on windows.
