### PR TITLE
Added missing instances to Snaplet

### DIFF
--- a/snap.cabal
+++ b/snap.cabal
@@ -126,6 +126,7 @@ Library
     cereal                    >= 0.3      && < 0.4,
     clientsession             >= 0.7.3.6  && < 0.8,
     configurator              >= 0.1      && < 0.3,
+    comonad                   >= 1.1      && < 3.1,
     containers                >= 0.3      && < 0.6,
     directory                 >= 1.0      && < 1.2,
     directory-tree            >= 0.10     && < 0.11,


### PR DESCRIPTION
There are a number of instances that can be made for Snaplet that are currently missing.

They expose no new functionality, as everything that you can do with them you could do before using the exposed lenses, this just provides a few new ways to do things using standard classes, so no safety is lost, and there isn't any canonical place these instances could live outside of the snap package since they would otherwise be orphans.
