### PR TITLE
A small documentation fix for Snap.Snaplet.Auth

### DIFF
--- a/src/Snap/Snaplet/Auth/SpliceHelpers.hs
+++ b/src/Snap/Snaplet/Auth/SpliceHelpers.hs
@@ -35,6 +35,7 @@ import           Snap.Snaplet.Heist
 -- This adds the following splices:
 -- \<ifLoggedIn\>
 -- \<ifLoggedOut\>
+-- \<loggedInUser\>
 addAuthSplices
   :: HasHeist b
   => Lens b (Snaplet (AuthManager b))


### PR DESCRIPTION
List <loggedInUser> as a splice added by `addAuthSplices`. (The docs currently mention only <ifLoggedIn> and <ifLoggedOut).
