### PR TITLE
Improve documentation of wrapSite, runSnaplet and serveSnaplet

### DIFF
--- a/src/Snap/Snaplet/Internal/Initializer.hs
+++ b/src/Snap/Snaplet/Internal/Initializer.hs
@@ -367,16 +367,11 @@ addRoutes rs = do
 
 
 ------------------------------------------------------------------------------
--- | Wraps the /base/ snaplet's routing. When all is said and done, a snaplet's
--- routes end up getting combined into a single 'Handler' action.  This function
--- allows you to modify that Handler before it actually gets served.  This
--- allows you to do things that need to happen for every request handled by your
--- snaplet.
+-- | Wraps the /base/ snaplet's routing in another handler, allowing you to run
+-- code before and after all routes in an application.
 --
--- As this wrap's the base snaplet, you are able to wrap all handlers of the
--- application. Here are some examples of things you might do:
+-- Here are some examples of things you might do:
 --
--- > wrapSite (\site -> removePathTrailingSlashes >> site)
 -- > wrapSite (\site -> logHandlerStart >> site >> logHandlerFinished)
 -- > wrapSite (\site -> ensureAdminUser >> site)
 --
@@ -514,12 +509,12 @@ runInitializer' mvar env b@(Initializer i) cwd = do
 
 
 ------------------------------------------------------------------------------
--- | Given an envirnoment and a Snaplet initializer, produce the set of
--- messages generated during initialization, a snap handler, and a cleanup
--- action.  The environment is an arbitrary string such as \"devel\" or
--- \"production\".  This string is used to determine the name of the config
--- files used each snaplet.  If an environment of Nothing is used, then
--- runSnaplet defaults to \"devel\".
+-- | Given an environment and a Snaplet initializer, produce a concatenated log
+-- of all messages generated during initialization, a snap handler, and a
+-- cleanup action.  The environment is an arbitrary string such as \"devel\" or
+-- \"production\".  This string is used to determine the name of the
+-- configuration files used by each snaplet.  If an environment of Nothing is
+-- used, then runSnaplet defaults to \"devel\".
 runSnaplet :: Maybe String -> SnapletInit b b -> IO (Text, Snap (), IO ())
 runSnaplet env (SnapletInit b) = do
     snapletMVar <- newEmptyMVar
@@ -550,8 +545,9 @@ combineConfig config handler = do
 
 
 ------------------------------------------------------------------------------
--- | Serves a top-level snaplet as a web application, reading command-line
--- arguments before starting a server.
+-- | Initialize and run a Snaplet. This function parses command-line arguments,
+-- runs the given Snaplet initializer, and starts an HTTP server running the
+-- Snaplet's toplevel 'Handler'.
 serveSnaplet :: Config Snap AppConfig
              -- ^ The configuration of the server - you can usually pass a
              -- default 'Config' via 'Snap.Http.Server.Config.defaultConfig'.


### PR DESCRIPTION
- wrapSite now clarifies that it wraps the base snaplet, not just the current snaplet.
- runSnaplet now correctly shows the string "devel", instead of trying to link to the `devel` identifier.
- serveSnaplet clearly documents both parameters, providing a hint that defaultConfig can be used. Also removed the FIXME comment.
