### PR TITLE
Update src/Snap/Snaplet/HeistNoClass.hs

### DIFF
--- a/src/Snap/Snaplet/HeistNoClass.hs
+++ b/src/Snap/Snaplet/HeistNoClass.hs
@@ -192,7 +192,7 @@ finalLoadHook (Configuring ref) = do
     (hs,cts) <- toTextErrors $ initHeistWithCacheTag hc
     return $ Running hs cts
   where
-    toTextErrors = mapEitherT (T.pack . intercalate "\n") id
+    toTextErrors = bimapEitherT (T.pack . intercalate "\n") id
 finalLoadHook (Running _ _) = left "finalLoadHook called while running"
 
 


### PR DESCRIPTION
either-3.1 changed `mapEitherT` to `bimapEitherT`. Cabal should require `either` package in order to properly check version in this file.
