### PR TITLE
Bump lens dependency to 3.9

### DIFF
--- a/project_template/default/foo.cabal
+++ b/project_template/default/foo.cabal
@@ -42,7 +42,7 @@ Executable projname
   else
     build-depends:
       base                      >= 4.4      && < 5,
-      lens                      >= 3.7.6    && < 3.9
+      lens                      >= 3.7.6    && < 3.10
 
   if flag(development)
     build-depends:

--- a/project_template/tutorial/foo.cabal
+++ b/project_template/tutorial/foo.cabal
@@ -33,7 +33,7 @@ Executable projname
   else
     build-depends:
       base                      >= 4.4      && < 5,
-      lens                      >= 3.7.6    && < 3.9
+      lens                      >= 3.7.6    && < 3.10
 
   if impl(ghc >= 6.12.0)
     ghc-options: -threaded -Wall -fwarn-tabs -funbox-strict-fields -O2

--- a/snap.cabal
+++ b/snap.cabal
@@ -184,7 +184,7 @@ Library
   else
     build-depends:
       base                      >= 4.4      && < 5,
-      lens                      >= 3.7.6    && < 3.9
+      lens                      >= 3.7.6    && < 3.10
 
   extensions:
     BangPatterns,

--- a/test/snap-testsuite.cabal
+++ b/test/snap-testsuite.cabal
@@ -65,7 +65,7 @@ Executable snap-testsuite
   else
     build-depends:
       base                      >= 4.4      && < 5,
-      lens                      >= 3.7.6    && < 3.9
+      lens                      >= 3.7.6    && < 3.10
 
 
   extensions:
@@ -136,7 +136,7 @@ Executable app
   else
     build-depends:
       base                      >= 4.4      && < 5,
-      lens                      >= 3.7.6    && < 3.9
+      lens                      >= 3.7.6    && < 3.10
 
   extensions:
     BangPatterns,
@@ -218,7 +218,7 @@ Executable nesttest
   else
     build-depends:
       base                      >= 4.4      && < 5,
-      lens                      >= 3.7.6    && < 3.9
+      lens                      >= 3.7.6    && < 3.10
 
 
   extensions:


### PR DESCRIPTION
Lens 3.9 has been released with attention to the versions of GHC that snap currently supports.
