### PR TITLE
Do not print snaplet snaplet messages if verbosity explicitly false

### DIFF
--- a/src/Snap/Snaplet/Internal/Initializer.hs
+++ b/src/Snap/Snaplet/Internal/Initializer.hs
@@ -593,10 +593,11 @@ serveSnaplet startConfig initializer = do
     createDirectoryIfMissing False "log"
     let serve = simpleHttpServe conf
 
-    liftIO $ hPutStrLn stderr $ T.unpack msgs
+    when (loggingEnabled conf) $ liftIO $ hPutStrLn stderr $ T.unpack msgs
     _ <- try $ serve $ site
          :: IO (Either SomeException ())
     doCleanup
+    where loggingEnabled = not . (== Just False) . getVerbose
 
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
This resolves issue #81. Only disables logging of initialization messages to stderr if verbosity is explicitly set to false in the config.
