### PR TITLE
Accept "on" value for remember me checkbox input value

### DIFF
--- a/src/Snap/Snaplet/Auth/Handlers.hs
+++ b/src/Snap/Snaplet/Auth/Handlers.hs
@@ -447,7 +447,7 @@ loginUser' unf pwdf remf = do
                     (runMaybeT $
                     do field <- MaybeT $ return remf
                        value <- MaybeT $ getParam field
-                       return $ value == "1")
+                       return $ value == "1" || value == "on")
 
     password <- noteT PasswordMissing $ hoistMaybe mbPassword
     username <- noteT UsernameMissing $ hoistMaybe mbUsername


### PR DESCRIPTION
Tested by adding a remember checkbox into the project default template login. I verified that a "remember_token" gets saved to a non-null value in the users.json after login.

I've copy&pasted my patch for adding "remember me" functionality into the comments of this pull request.

```
Accept a value of "on" for login screen's "remember me" input value.
This is what gets sent as default by the browser when an
<input type="checkbox"> is checked.

Previously only "1" was accepted which meant checkboxes would need to
explicitly specify a value="1" in their definition.

Fixes #96
```
