### PR TITLE
BACKPORT: Add support in Snap.Snaplet.Test for reusing initializers.

### DIFF
--- a/src/Snap/Snaplet/Test.hs
+++ b/src/Snap/Snaplet/Test.hs
@@ -4,7 +4,12 @@ module Snap.Snaplet.Test
   (
     -- ** Testing handlers
     evalHandler
+  , evalHandler'
   , runHandler
+  , runHandler'
+  , getSnaplet
+  , closeSnaplet
+  , InitializerState
   , withTemporaryFile
   )
   where
@@ -15,7 +20,8 @@ import           Control.Concurrent.MVar
 import           Control.Exception.Base (finally)
 import qualified Control.Exception as E
 import           Control.Monad.IO.Class
-import           Data.Maybe (fromMaybe) 
+import           Control.Monad (join)
+import           Data.Maybe (fromMaybe)
 import           Data.IORef
 import           Data.Text
 import           System.Directory
@@ -52,7 +58,7 @@ removeFileMayNotExist f = catchNonExistence (removeFile f) ()
 
 ------------------------------------------------------------------------------
 -- | Helper to keep "runHandler" and "evalHandler" DRY.
-execHandlerComputation :: MonadIO m 
+execHandlerComputation :: MonadIO m
                        => (RequestBuilder m () -> Snap v -> m a)
                        -> Maybe String
                        -> RequestBuilder m ()
@@ -63,13 +69,23 @@ execHandlerComputation f env rq h s = do
     app <- getSnaplet env s
     case app of
       (Left e) -> return $ Left e
-      (Right (a, is)) -> do
-          res <- f rq $ runPureBase h a
-          -- Run the cleanup action
-          liftIO $ do
-              cleanupAction <- readIORef $ _cleanup is
-              cleanupAction
-          return $ Right res
+      (Right (a, is)) -> execHandlerSnaplet a is f rq h
+
+
+------------------------------------------------------------------------------
+-- | Helper to allow multiple calls to "runHandler" or "evalHandler" without
+-- multiple initializations.
+execHandlerSnaplet :: MonadIO m
+                   => Snaplet b
+                   -> InitializerState b
+                   -> (RequestBuilder m () -> Snap v -> m a)
+                   -> RequestBuilder m ()
+                   -> Handler b b v
+                   -> m (Either Text a)
+execHandlerSnaplet a is f rq h = do
+  res <- f rq $ runPureBase h a
+  closeSnaplet is
+  return $ Right res
 
 ------------------------------------------------------------------------------
 -- | Given a Snaplet Handler and a 'RequestBuilder' defining
@@ -86,6 +102,18 @@ runHandler :: MonadIO m
            -> m (Either Text Response)
 runHandler = execHandlerComputation ST.runHandler
 
+------------------------------------------------------------------------------
+-- | A variant of runHandler that takes the Snaplet and InitializerState as
+-- produced by getSnaplet, so those can be re-used across requests. It does not
+-- run cleanup actions, so closeSnaplet should be used when finished.
+runHandler' :: MonadIO m
+            => Snaplet b
+            -> InitializerState b
+            -> RequestBuilder m ()
+            -> Handler b b v
+            -> m (Either Text Response)
+runHandler' a is = execHandlerSnaplet a is ST.runHandler
+
 
 ------------------------------------------------------------------------------
 -- | Given a Snaplet Handler, a 'SnapletInit' specifying the initial state,
@@ -99,7 +127,7 @@ runHandler = execHandlerComputation ST.runHandler
 -- 'evalHandler defined in Snap.Test, because due to the fact running
 -- the initializer inside 'SnapletInit' can throw an exception.
 evalHandler :: MonadIO m
-            => Maybe String 
+            => Maybe String
             -> RequestBuilder m ()
             -> Handler b b a
             -> SnapletInit b b
@@ -108,11 +136,23 @@ evalHandler = execHandlerComputation ST.evalHandler
 
 
 ------------------------------------------------------------------------------
+-- | A variant of evalHandler that takes the Snaplet and InitializerState as
+-- produced by getSnaplet, so those can be re-used across requests. It does not
+-- run cleanup actions, so closeSnaplet should be used when finished.
+evalHandler' :: MonadIO m
+             => Snaplet b
+             -> InitializerState b
+             -> RequestBuilder m ()
+             -> Handler b b a
+             -> m (Either Text a)
+evalHandler' a is = execHandlerSnaplet a is ST.evalHandler
+
+------------------------------------------------------------------------------
 -- | Run the given initializer, yielding a tuple where the first element is
 -- a @Snaplet b@, or an error message whether the initializer threw an
--- exception.                                                       
+-- exception. This is only needed for runHandler'/evalHandler'.
 getSnaplet :: MonadIO m
-           => Maybe String  
+           => Maybe String
            -> SnapletInit b b
            -> m (Either Text (Snaplet b, InitializerState b))
 getSnaplet env (SnapletInit initializer) = liftIO $ do
@@ -120,3 +160,11 @@ getSnaplet env (SnapletInit initializer) = liftIO $ do
     let resetter f = modifyMVar_ mvar (return . f)
     runInitializer resetter (fromMaybe "devel" env) initializer
 
+------------------------------------------------------------------------------
+-- | Run cleanup for an initializer. Should be run after finished using the
+-- state that getSnaplet returned. Only needed if using getSnaplet and
+-- evalHandler'/runHandler'.
+closeSnaplet :: MonadIO m
+             => InitializerState b
+             -> m ()
+closeSnaplet is = liftIO $ join (readIORef $ _cleanup is)

--- a/test/runTestsAndCoverage.sh
+++ b/test/runTestsAndCoverage.sh
@@ -43,6 +43,8 @@ Snap.Snaplet.Internal.LensT.Tests
 Snap.Snaplet.Internal.RST.Tests
 Snap.Snaplet.Internal.Tests
 Snap.TestCommon
+Snap.Snaplet.Test.App
+Snap.Snaplet.Test.Tests
 '
 
 EXCL=""

--- a/test/suite/Snap/Snaplet/Test/App.hs
+++ b/test/suite/Snap/Snaplet/Test/App.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE PackageImports      #-}
+{-# LANGUAGE TemplateHaskell     #-}
+
+
+module Snap.Snaplet.Test.App
+ ( App(..)
+ , appInit
+ , failingAppInit
+ ) where
+
+
+------------------------------------------------------------------------------
+import           Control.Lens
+import           Control.Monad.Trans (liftIO)
+------------------------------------------------------------------------------
+import           Snap.Snaplet
+
+
+------------------------------------------------------------------------------
+data App = App
+
+makeLenses ''App
+
+
+------------------------------------------------------------------------------
+appInit :: SnapletInit App App
+appInit = makeSnaplet "app" "Test application" Nothing $ do
+   return App
+
+failingAppInit :: SnapletInit App App
+failingAppInit = makeSnaplet "app" "Test application" Nothing $ do
+   error "Error"
+   return App

--- a/test/suite/Snap/Snaplet/Test/Tests.hs
+++ b/test/suite/Snap/Snaplet/Test/Tests.hs
@@ -1,0 +1,93 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Snap.Snaplet.Test.Tests
+  ( tests ) where
+
+
+------------------------------------------------------------------------------
+import qualified Data.Map as Map
+import           Test.Framework
+import           Test.Framework.Providers.HUnit
+import           Test.HUnit hiding (Test, path)
+
+
+------------------------------------------------------------------------------
+import           Snap.Core
+import qualified Snap.Test as ST
+import           Snap.Snaplet.Test
+import           Snap.Snaplet.Test.App
+
+------------------------------------------------------------------------------
+tests :: Test
+tests = testGroup "Snap.Snaplet.Test"
+    [ testRunHandler
+    , testRunHandler'
+    , testEvalHandler
+    , testEvalHandler'
+    , testFailingEvalHandler
+    , testFailingGetSnaplet
+    ]
+
+testRunHandler :: Test
+testRunHandler = testCase "runHandler simple" assertRunHandler
+  where
+    assertRunHandler :: Assertion
+    assertRunHandler = do let hdl = writeText "Hello!"
+                          res <- runHandler Nothing (ST.get "" Map.empty) hdl appInit
+                          either (assertFailure . show)
+                                 (ST.assertBodyContains "Hello!") res
+
+testRunHandler' :: Test
+testRunHandler' = testCase "runHandler' simple" assertRunHandler'
+  where
+    assertRunHandler' :: Assertion
+    assertRunHandler' = do let hdl = writeText "Hello!"
+                           init <- getSnaplet Nothing appInit
+                           case init of
+                             Left err -> assertFailure (show err)
+                             Right (a,is) -> do
+                               res <- runHandler' a is (ST.get "" Map.empty) hdl
+                               closeSnaplet is
+                               either (assertFailure . show)
+                                      (ST.assertBodyContains "Hello!") res
+
+testEvalHandler :: Test
+testEvalHandler = testCase "evalHandler simple" assertEvalHandler
+  where
+    assertEvalHandler :: Assertion
+    assertEvalHandler = do let hdl = return "1+1=2"
+                           res <- evalHandler Nothing (ST.get "" Map.empty) hdl appInit
+                           either (assertFailure . show)
+                                  (assertEqual "" "1+1=2") res
+testEvalHandler' :: Test
+testEvalHandler' = testCase "evalHandler' simple" assertEvalHandler'
+  where
+    assertEvalHandler' :: Assertion
+    assertEvalHandler' = do let hdl = return "1+1=2"
+                            init <- getSnaplet Nothing appInit
+                            case init of
+                              Left err -> assertFailure (show err)
+                              Right (a,is) -> do
+                                res <- evalHandler' a is (ST.get "" Map.empty) hdl
+                                closeSnaplet is
+                                either (assertFailure . show)
+                                       (assertEqual "" "1+1=2") res
+
+testFailingEvalHandler :: Test
+testFailingEvalHandler = testCase "evalHandler failing simple" assertEvalHandler
+  where
+    assertEvalHandler :: Assertion
+    assertEvalHandler = do let hdl = return "1+1=2"
+                           res <- evalHandler Nothing (ST.get "" Map.empty) hdl failingAppInit
+                           case res of
+                             Left _ -> assertBool "" True
+                             Right _ -> assertFailure "Should have failed in initializer"
+
+testFailingGetSnaplet :: Test
+testFailingGetSnaplet = testCase "getSnaplet failing" assertGetSnaplet
+ where
+   assertGetSnaplet :: Assertion
+   assertGetSnaplet = do init <- getSnaplet Nothing failingAppInit
+                         case init of
+                           Left _ -> assertBool "" True
+                           Right _ -> assertFailure "Should have failed in initializer"

--- a/test/suite/TestSuite.hs
+++ b/test/suite/TestSuite.hs
@@ -29,6 +29,7 @@ import qualified Snap.Snaplet.Internal.LensT.Tests
 import qualified Snap.Snaplet.Internal.RST.Tests
 import qualified Snap.Snaplet.Internal.Tests
 import qualified Snap.Snaplet.Auth.Tests
+import qualified Snap.Snaplet.Test.Tests
 import           Snap.TestCommon
 
 import           SafeCWD
@@ -52,6 +53,7 @@ main = do
   where tests = mutuallyExclusive $
                 testGroup "snap" [ internalServerTests
                                  , Snap.Snaplet.Auth.Tests.tests
+                                 , Snap.Snaplet.Test.Tests.tests
                                  , testDefault
                                  , testBarebones
                                  , testTutorial
@@ -140,5 +142,3 @@ testTutorial = testCase "snap/tutorial" go
     testIt = do
         body <- get (S.pack $ "http://127.0.0.1:"++(show port)++"/hello") concatHandler
         assertEqual "server not up" "hello world" body
-
-


### PR DESCRIPTION
This was a change that was originally against 0.13, but got merged after master switched to 1.0 (the same day, even!). I'm in the process of doing a proper release of a testing library that could really use these changes to be on the current stable (it speeds up test suites by 10-100x). All tests pass on 0.13 with these changes.
