### PR TITLE
serveSnaplet should use httpServe

### DIFF
--- a/src/Snap/Snaplet/Internal/Initializer.hs
+++ b/src/Snap/Snaplet/Internal/Initializer.hs
@@ -59,8 +59,7 @@ import           Prelude                      (Bool (..), Either (..), Eq (..),
 import           Snap.Core                    (Snap, liftSnap, route)
 import           Snap.Http.Server             (Config, completeConfig,
                                                getCompression, getErrorHandler,
-                                               getOther, getVerbose,
-                                               simpleHttpServe)
+                                               getOther, getVerbose, httpServe)
 import           Snap.Util.GZip               (withCompression)
 import           System.Directory             (copyFile,
                                                createDirectoryIfMissing,
@@ -629,7 +628,7 @@ serveSnaplet startConfig initializer = do
 
     (conf, site) <- combineConfig config handler
     createDirectoryIfMissing False "log"
-    let serve = simpleHttpServe conf
+    let serve = httpServe conf
 
     when (loggingEnabled conf) $ liftIO $ hPutStrLn stderr $ T.unpack msgs
     _ <- try $ serve $ site


### PR DESCRIPTION
simpleHttpServe does not setup reverse proxy, this makes serveSnaplet unusable behind proxy. Though user can add behindProxy combinator to his routes, routes installed by snaplets, like heist will not work properly.

For example you can access heist reload route on snap homepage, because it thinks you are accessing from localhost.

So either serveSnaplet should receive huge warning in docs concerning this behaviour, and example of proper usage of runSnaplet together with httpServe. Or switch to httpServe.
