### PR TITLE
Set proper path of remember cookie when expiring

### DIFF
--- a/src/Snap/Snaplet/Auth/Handlers.hs
+++ b/src/Snap/Snaplet/Auth/Handlers.hs
@@ -327,7 +327,7 @@ setRememberToken sk rc rp token = setSecureCookie rc sk rp token
 
 ------------------------------------------------------------------------------
 forgetRememberToken :: MonadSnap m => ByteString -> m ()
-forgetRememberToken rc = expireCookie rc (Just "/")
+forgetRememberToken rc = expireCookie rc Nothing (Just "/")
 
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
Same path as used in setSecureCookie
Together with snapframework/snap-core#212