### PR TITLE
Remove dependency on errors, depend on either instead

### DIFF
--- a/snap.cabal
+++ b/snap.cabal
@@ -91,6 +91,7 @@ Library
     Snap.Snaplet.Auth.AuthManager
     Snap.Snaplet.Auth.Types
     Snap.Snaplet.Auth.Handlers
+    Snap.Snaplet.Auth.Handlers.Errors
     Snap.Snaplet.Auth.SpliceHelpers
     Snap.Snaplet.Heist.Internal
     Snap.Snaplet.Internal.Initializer
@@ -112,7 +113,7 @@ Library
     directory                 >= 1.0      && < 1.3,
     directory-tree            >= 0.11     && < 0.13,
     dlist                     >= 0.5      && < 0.8,
-    errors                    >= 1.4      && < 1.5,
+    either                    >= 4.3      && < 4.5,
     filepath                  >= 1.1      && < 1.5,
     -- Blacklist bad versions of hashable
     hashable                  (>= 1.1 && < 1.2) || (>= 1.2.0.6 && <1.3),

--- a/src/Snap/Snaplet/Auth/Handlers.hs
+++ b/src/Snap/Snaplet/Auth/Handlers.hs
@@ -11,9 +11,11 @@ module Snap.Snaplet.Auth.Handlers where
 
 ------------------------------------------------------------------------------
 import           Control.Applicative
-import           Control.Error
 import           Control.Monad.State
+import           Control.Monad.Trans.Either
+import           Control.Monad.Trans.Maybe
 import           Data.ByteString (ByteString)
+import           Data.Maybe
 import           Data.Serialize hiding (get)
 import           Data.Time
 import           Data.Text.Encoding (decodeUtf8)
@@ -24,6 +26,7 @@ import           Web.ClientSession
 import           Snap.Core
 import           Snap.Snaplet
 import           Snap.Snaplet.Auth.AuthManager
+import           Snap.Snaplet.Auth.Handlers.Errors
 import           Snap.Snaplet.Auth.Types
 import           Snap.Snaplet.Session
 ------------------------------------------------------------------------------

--- a/src/Snap/Snaplet/Auth/Handlers/Errors.hs
+++ b/src/Snap/Snaplet/Auth/Handlers/Errors.hs
@@ -1,0 +1,33 @@
+-- | An internal module that copies a few select functions
+-- from Control.Error.Util, as used in Snap.Snaplet.Auth.Handlers.
+module Snap.Snaplet.Auth.Handlers.Errors
+  ( hush
+  , hushT
+  , note
+  , noteT
+  , hoistMaybe
+  ) where
+
+import Control.Monad
+import Control.Monad.Trans.Either
+import Control.Monad.Trans.Maybe
+
+-- | Suppress the 'Left' value of an 'Either'
+hush :: Either a b -> Maybe b
+hush = either (const Nothing) Just
+
+-- | Suppress the 'Left' value of an 'EitherT'
+hushT :: (Monad m) => EitherT a m b -> MaybeT m b
+hushT = MaybeT . liftM hush . runEitherT
+
+-- | Tag the 'Nothing' value of a 'Maybe'
+note :: a -> Maybe b -> Either a b
+note a = maybe (Left a) Right
+
+-- | Tag the 'Nothing' value of a 'MaybeT'
+noteT :: (Monad m) => a -> MaybeT m b -> EitherT a m b
+noteT a = EitherT . liftM (note a) . runMaybeT
+
+-- | Lift a 'Maybe' to the 'MaybeT' monad
+hoistMaybe :: (Monad m) => Maybe b -> MaybeT m b
+hoistMaybe = MaybeT . return

--- a/src/Snap/Snaplet/Heist/Internal.hs
+++ b/src/Snap/Snaplet/Heist/Internal.hs
@@ -2,9 +2,9 @@
 module Snap.Snaplet.Heist.Internal where
 
 import           Prelude
-import           Control.Error
 import           Control.Lens
 import           Control.Monad.State
+import           Control.Monad.Trans.Either
 import qualified Data.HashMap.Strict as Map
 import           Data.IORef
 import           Data.List

--- a/src/Snap/Snaplet/HeistNoClass.hs
+++ b/src/Snap/Snaplet/HeistNoClass.hs
@@ -63,15 +63,16 @@ module Snap.Snaplet.HeistNoClass
 import           Prelude hiding ((.), id)
 import           Control.Applicative
 import           Control.Category
-import           Control.Error
 import           Control.Lens
 import           Control.Monad.Reader
 import           Control.Monad.State
+import           Control.Monad.Trans.Either
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as B
 import           Data.DList (DList)
 import qualified Data.HashMap.Strict as Map
 import           Data.IORef
+import           Data.Maybe
 import           Data.Monoid
 import qualified Data.Text as T
 import           Data.Text.Encoding

--- a/src/Snap/Snaplet/Internal/Initializer.hs
+++ b/src/Snap/Snaplet/Internal/Initializer.hs
@@ -30,8 +30,6 @@ module Snap.Snaplet.Internal.Initializer
 ------------------------------------------------------------------------------
 import           Control.Concurrent.MVar      (MVar, modifyMVar_, newEmptyMVar,
                                                putMVar, readMVar)
-import           Control.Error                (EitherT, either, right,
-                                               runEitherT)
 import           Control.Exception.Lifted     (SomeException, catch, try)
 import           Control.Lens                 (ALens', cloneLens, over, set,
                                                storing, (^#))
@@ -40,6 +38,7 @@ import           Control.Monad                (Monad (..), join, liftM, unless,
 import           Control.Monad.Reader         (ask)
 import           Control.Monad.State          (get, modify)
 import           Control.Monad.Trans          (lift, liftIO)
+import           Control.Monad.Trans.Either   (EitherT, right, runEitherT)
 import           Control.Monad.Trans.Writer   hiding (pass)
 import           Data.ByteString.Char8        (ByteString)
 import qualified Data.ByteString.Char8        as B
@@ -53,7 +52,8 @@ import           Data.Maybe                   (Maybe (..), fromJust, fromMaybe,
 import           Data.Text                    (Text)
 import qualified Data.Text                    as T
 import           Prelude                      (Bool (..), Either (..), Eq (..),
-                                               String, concat, concatMap, const,
+                                               String, concat, concatMap,
+                                               const, either,
                                                error, filter, flip, fst, id,
                                                map, not, show, ($), ($!), (++),
                                                (.))

--- a/src/Snap/Snaplet/Internal/Types.hs
+++ b/src/Snap/Snaplet/Internal/Types.hs
@@ -17,12 +17,12 @@ module Snap.Snaplet.Internal.Types where
 
 ------------------------------------------------------------------------------
 import           Control.Applicative          (Alternative, Applicative)
-import           Control.Error                (EitherT)
 import           Control.Lens                 (ALens', makeLenses, set)
 import           Control.Monad.Base           (MonadBase (..))
 import           Control.Monad.Reader         (MonadIO (..), MonadPlus, MonadReader (ask, local), liftM, (>=>))
 import           Control.Monad.State.Class    (MonadState (get, put), gets)
 import           Control.Monad.Trans.Control  (MonadBaseControl (..))
+import           Control.Monad.Trans.Either   (EitherT)
 import           Control.Monad.Trans.Writer   (WriterT)
 import           Data.ByteString              (ByteString)
 import qualified Data.ByteString.Char8        as B (dropWhile, intercalate, null, reverse)


### PR DESCRIPTION
Rather than modify existing code, I found it preferable to just copy the small slice of `errors` that was needed. (Like snap, errors is BSD3 licensed.)

This PR is in the same spirit as https://github.com/snapframework/heist/pull/67.