### PR TITLE
Bump dlist upper bound to 0.9

### DIFF
--- a/snap.cabal
+++ b/snap.cabal
@@ -113,7 +113,7 @@ Library
     containers                >= 0.3      && < 0.6,
     directory                 >= 1.0      && < 1.3,
     directory-tree            >= 0.11     && < 0.13,
-    dlist                     >= 0.5      && < 0.8,
+    dlist                     >= 0.5      && < 0.9,
     filepath                  >= 1.1      && < 1.5,
     -- hashable is broken from 1.2.0.0 through 1.2.0.5
     -- snap does work with hashable 1.1.*, but some have complained that


### PR DESCRIPTION
I just released [`dlist-0.8`](https://github.com/spl/dlist/releases/tag/v0.8). I didn't test this change to `snap`, but I don't think it will be break anything.