### PR TITLE
Add support for aeson 1.0.* (fixes #180)

### DIFF
--- a/snap.cabal
+++ b/snap.cabal
@@ -103,7 +103,7 @@ Library
     Snap.Snaplet.Session.SecureCookie
 
   build-depends:
-    aeson                     >= 0.6      && < 0.12,
+    aeson                     >= 0.6      && < 1.1,
     attoparsec                >= 0.10     && < 0.14,
     base                      >= 4        && < 5,
     bytestring                >= 0.9.1    && < 0.11,

--- a/src/Snap/Snaplet/Auth/Backends/JsonFile.hs
+++ b/src/Snap/Snaplet/Auth/Backends/JsonFile.hs
@@ -89,11 +89,15 @@ mkJsonAuthMgr fp = do
 ------------------------------------------------------------------------------
 type UserIdCache = Map UserId AuthUser
 
+#if !MIN_VERSION_aeson(1,0,0)
+-- In aeson >= 1 these instances are not needed because we have
+-- derived ToJSONKey/FromJSONKey instances for UserId.
 instance ToJSON UserIdCache where
   toJSON m = toJSON $ HM.toList m
 
 instance FromJSON UserIdCache where
   parseJSON = fmap HM.fromList . parseJSON
+#endif
 
 ------------------------------------------------------------------------------
 type LoginUserCache = Map Text UserId

--- a/src/Snap/Snaplet/Auth/Types.hs
+++ b/src/Snap/Snaplet/Auth/Types.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE ExistentialQuantification  #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE StandaloneDeriving         #-}
 
 module Snap.Snaplet.Auth.Types where
 
@@ -113,6 +114,10 @@ instance Show AuthFailure where
 newtype UserId = UserId { unUid :: Text }
   deriving ( Read, Show, Ord, Eq, FromJSON, ToJSON, Hashable )
 
+#if MIN_VERSION_aeson(1,0,0)
+deriving instance FromJSONKey UserId
+deriving instance ToJSONKey UserId
+#endif
 
 ------------------------------------------------------------------------------
 -- | This will be replaced by a role-based permission system.


### PR DESCRIPTION
For aeson 1.0.* this adds `ToJSONKey`/`FromJSONKey` instances to UserId
and removes the overlapping `ToJSON`/`FromJSON` instances for UserIdCache.