### PR TITLE
Fix snap-templates package name in README and Cabal file

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The testsuite generates an `hpc` test coverage report in `dist/hpc`.
 
 ## Roadmap to Understanding Snaplets
 
-1. Read `Tutorial.lhs` which is in the `project_template/tutorial/src` directory of the `snap-template` package.
+1. Read `Tutorial.lhs` which is in the `project_template/tutorial/src` directory of the `snap-templates` package.
 2. Generate and read the haddock docs.
 3. The test code has the nice property that it actually functions as a pretty good example app and covers a lot of the use cases.
 4. If you're interested in the implementation, read design.md.

--- a/snap.cabal
+++ b/snap.cabal
@@ -11,7 +11,7 @@ description:
     .
     To get started, issue the following sequence of commands:
     .
-    @$ cabal install snap snap-template
+    @$ cabal install snap snap-templates
     $ mkdir myproject
     $ cd myproject
     $ snap init@
@@ -21,7 +21,7 @@ description:
     (<http://snapframework.com/docs>).
     .
     Note: since version 1.0, the \"snap\" executable program for generating
-    starter projects is provided by the @snap-template@ package.
+    starter projects is provided by the @snap-templates@ package.
 
 license:        BSD3
 license-file:   LICENSE


### PR DESCRIPTION
There are three mentions of the snap-templates package which say snap-template instead of snap-templates. This simply corrects such mentions.