### PR TITLE
Allow lens 4.15.* and QuickCheck 2.9.*

### DIFF
--- a/snap.cabal
+++ b/snap.cabal
@@ -120,7 +120,7 @@ Library
     -- the version disjunction causes problems with dependency resolution.
     hashable                  >= 1.2.0.6  && < 1.3,
     heist                     >= 1.0      && < 1.1,
-    lens                      >= 3.7.6    && < 4.15,
+    lens                      >= 3.7.6    && < 4.16,
     lifted-base               >= 0.2      && < 0.3,
     map-syntax                >= 0.2      && < 0.3,
     monad-control             >= 0.3      && < 1.1,
@@ -245,7 +245,7 @@ Test-suite testsuite
     mtl,
     mwc-random,
     pwstore-fast,
-    QuickCheck                 >= 2.4.2    && < 2.9,
+    QuickCheck                 >= 2.4.2    && < 2.10,
     smallcheck                 >= 1.1.1    && < 1.2,
     snap-core,
     snap-server,


### PR DESCRIPTION
Depends on snapframework/heist#97
