### PR TITLE
Compiles with ghc 8.6.1

### DIFF
--- a/src/Snap/Snaplet/HeistNoClass.hs
+++ b/src/Snap/Snaplet/HeistNoClass.hs
@@ -289,8 +289,11 @@ iRenderHelper :: Maybe MIMEType
              -> ByteString
              -> Handler b (Heist b) ()
 iRenderHelper c t = do
-    (Running _ hs _ _) <- get
-    withTop' id $ I.renderTemplate hs t >>= maybe pass serve
+    r <- get
+    case r of
+      (Running _ hs _ _) ->
+        withTop' id $ I.renderTemplate hs t >>= maybe pass serve
+      _ -> error "pattern match failed in iRenderHelper"
   where
     serve (b, mime) = do
         modifyResponse $ setContentType $ fromMaybe mime c
@@ -303,8 +306,11 @@ cRenderHelper :: Maybe MIMEType
               -> ByteString
               -> Handler b (Heist b) ()
 cRenderHelper c t = do
-    (Running _ hs _ _) <- get
-    withTop' id $ maybe pass serve $ C.renderTemplate hs t
+    r <- get
+    case r of
+      (Running _ hs _ _) ->
+        withTop' id $ maybe pass serve $ C.renderTemplate hs t
+      _ -> error "pattern match failed in cRenderHelper"
   where
     serve (b, mime) = do
         modifyResponse $ setContentType $ fromMaybe mime c


### PR DESCRIPTION
When I compile snap with ghc-8.6.1 I get:

src/Snap/Snaplet/HeistNoClass.hs:294:5: error:
• No instance for (Control.Monad.Fail.MonadFail
(Handler b (Heist b)))
arising from a do statement
with the failable pattern ‘(Running _ hs _ _)’
• In a stmt of a 'do' block: (Running _ hs _ _) <- get
In the expression:
do (Running _ hs _ _) <- get
withTop' id $ I.renderTemplate hs t >>= maybe pass serve
In an equation for ‘iRenderHelper’:
iRenderHelper c t
= do (Running _ hs _ _) <- get
withTop' id $ I.renderTemplate hs t >>= maybe pass serve
where
serve (b, mime)
= do modifyResponse $ setContentType $ fromMaybe mime c
....
|
294 | (Running _ hs _ _) <- get
| ^^^^^^^^^^^^^^^^^^^^^^^^^

src/Snap/Snaplet/HeistNoClass.hs:308:5: error:
• No instance for (Control.Monad.Fail.MonadFail
(Handler b (Heist b)))
arising from a do statement
with the failable pattern ‘(Running _ hs _ _)’
• In a stmt of a 'do' block: (Running _ hs _ _) <- get
In the expression:
do (Running _ hs _ _) <- get
withTop' id $ maybe pass serve $ C.renderTemplate hs t
In an equation for ‘cRenderHelper’:
cRenderHelper c t
= do (Running _ hs _ _) <- get
withTop' id $ maybe pass serve $ C.renderTemplate hs t
where
serve (b, mime)
= do modifyResponse $ setContentType $ fromMaybe mime c
....
|
308 | (Running _ hs _ _) <- get
| ^^^^^^^^^^^^^^^^^^^^^^^^^

This patch fixes it.