### PR TITLE
Fail via fail, not MonadFail, when available

### DIFF
--- a/src/Snap/Snaplet/Internal/RST.hs
+++ b/src/Snap/Snaplet/Internal/RST.hs
@@ -91,8 +91,8 @@ rwsBind m f = RST go
 instance (Monad m) => Monad (RST r s m) where
     return a = RST $ \_ s -> return (a, s)
     (>>=)    = rwsBind
-#if !MIN_VERSION_base(4,11,0)
-    fail = Fail.fail
+#if !MIN_VERSION_base(4,13,0)
+    fail msg = RST $ \_ _ -> fail msg
 #endif
 
 instance Fail.MonadFail m => Fail.MonadFail (RST r s m) where


### PR DESCRIPTION
Rely on the `Monad` class definition of `fail` as long as `fail` is a method of `Monad` (all ghc's before 8.2.2).

Otherwise, a user calling `fail` in `RST` will encounter the default definition of `fail`, which is `error`.