### PR TITLE
Require directory-tree >= 0.11

### DIFF
--- a/snap.cabal
+++ b/snap.cabal
@@ -149,7 +149,7 @@ Library
     configurator              >= 0.1      && < 0.4,
     containers                >= 0.2      && < 0.7,
     directory                 >= 1.1      && < 1.4,
-    directory-tree            >= 0.10     && < 0.13,
+    directory-tree            >= 0.11     && < 0.13,
     dlist                     >= 0.5      && < 1.1,
     fail                      >= 4.9      && < 4.10,
     filepath                  >= 1.3      && < 1.5,


### PR DESCRIPTION
`System.Directory.Tree.dirTree` is not available before `directory-tree-0.11.0`.