### PR TITLE
QC 2.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,10 @@ on:
   push:
     branches:
       - 'master'
-  schedule:
-    # Additionally run once per week (At 00:00 on Sunday) to maintain cache.
-    - cron: '0 0 * * 0'
+  # Disable scheduled runs since GitHub will disable the whole action after a while.
+  # schedule:
+  #   # Additionally run once per week (At 00:00 on Sunday) to maintain cache.
+  #   - cron: '0 0 * * 0'
 
 jobs:
   cabal:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
           - "9.6"
           - "9.8"
           - "9.10"
+          - "9.12"
         # TODO: HsOpenSSL fails to build on Windows and macOS without openssl.
         # include:
         #  - { os: macOS-latest,   ghc: "9.8" }
@@ -96,8 +97,8 @@ jobs:
         include:
           # GHC version must match https://www.stackage.org/nightly
           - stack: "latest"
-            ghc: "9.8"
-            resolver: "nightly-2024-05-21"
+            ghc: "9.10"
+            resolver: "nightly-2025-06-18"
             # Note: this resolver is only a placeholder;
             # it is overwritten later by `stack config set resolver nightly`.
 

--- a/snap.cabal
+++ b/snap.cabal
@@ -1,6 +1,9 @@
 cabal-version:  2.2
 name:           snap
 version:        1.1.3.3
+-- Remove x-revision when bumping version
+x-revision:     4
+
 synopsis:       Top-level package for the Snap Web Framework
 description:
     This is the top-level package for the official Snap Framework libraries.
@@ -151,7 +154,7 @@ Library
     cereal                    >= 0.3      && < 0.6,
     clientsession             >= 0.8      && < 0.10,
     configurator              >= 0.1      && < 0.4,
-    containers                >= 0.2      && < 0.8,
+    containers                >= 0.2      && < 1,
     directory                 >= 1.1      && < 1.4,
     directory-tree            >= 0.11     && < 0.13,
     dlist                     >= 0.5      && < 1.1,
@@ -269,7 +272,7 @@ Test-suite testsuite
     mtl,
     mwc-random,
     pwstore-fast,
-    QuickCheck                 >= 2.4.2    && < 2.16,
+    QuickCheck                 >= 2.4.2    && < 3,
     smallcheck                 >= 1.1.1    && < 1.3,
     snap-core,
     snap-server,

--- a/snap.cabal
+++ b/snap.cabal
@@ -39,9 +39,10 @@ tested-with:
   GHC == 9.0.2
   GHC == 9.2.8
   GHC == 9.4.8
-  GHC == 9.6.6
-  GHC == 9.8.2
-  GHC == 9.10.1
+  GHC == 9.6.7
+  GHC == 9.8.4
+  GHC == 9.10.2
+  GHC == 9.12.2
 
 extra-source-files:
   .ghci,


### PR DESCRIPTION
- **CI: disable scheduled runs**
  

- **CI: bump to GHC 9.12 (cabal) / 9.10 (stack)**
  

- **v1.1.3.3 revision 4: allow QuickCheck <3 and containers <1** published to hackage
  